### PR TITLE
Improve OGRN detection for individual entrepreneurs

### DIFF
--- a/tests/test_zcb_client.py
+++ b/tests/test_zcb_client.py
@@ -1,0 +1,34 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from zcb_client import _find_first, OGRN_KEYS
+
+
+def test_find_first_prefers_matching_segment_over_date():
+    body = {
+        "egrip": {
+            "ogrn": "123456789012345",
+            "ogrn_date": "2020-01-01",
+        }
+    }
+
+    assert _find_first(body, OGRN_KEYS) == "123456789012345"
+
+
+def test_find_first_matches_egrip_ogrnip():
+    body = {
+        "body": {
+            "egrip": {
+                "ogrnip": "314159265358979",
+                "ogrn_date": "2030-12-31",
+            }
+        }
+    }
+
+    assert _find_first(body, OGRN_KEYS) == "314159265358979"


### PR DESCRIPTION
## Summary
- adjust partial matching in `_find_first` to prefer keys whose last segment matches the synonym and ignore *_date fields
- extend `OGRN_KEYS` with individual entrepreneur variants so exact matches can be found
- add regression tests covering IP payloads to ensure the OGRN number is extracted instead of the registration date

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68de6d81752083209f82bc432d5a741e